### PR TITLE
Fix error when encountering unseen LiveView

### DIFF
--- a/lib/sportyweb/rbac/policy.ex
+++ b/lib/sportyweb/rbac/policy.ex
@@ -29,8 +29,19 @@ defmodule Sportyweb.RBAC.Policy do
     end
   end
 
-  defp get_live_view(view),
-    do: view |> Kernel.inspect() |> String.split(".") |> Enum.at(1) |> String.to_existing_atom()
+  defp get_live_view(view) do
+    view_str =
+      view
+      |> Kernel.inspect()
+      |> String.split(".")
+      |> Enum.at(1)
+
+    try do
+      String.to_existing_atom(view_str)
+    rescue
+      ArgumentError -> String.to_atom(view_str)
+    end
+  end
 
   # <--- Policy check for application admins ---> #
   def is_application_admin_or_tester(user) do


### PR DESCRIPTION
get_live_view sometimes ran into an error:
** (ArgumentError) 1st argument: not an already existing atom: "ContractLive"

The Policy module tries to check the policy for the LiveView using the module name as atom, but the LiveView was not initialized yet, so the to_existing_atom runs into an error.  Its not happening deterministically, but I encountered it when loading the Contract LiveView and with a newly created Document LiveView. 

The fix makes the to_existing_atom fail silently and creates the atom from string if the atom does not exist. While creating atoms from string can be dangerous on unchecked input, the range of possible input strings is controlled by the existing views.

